### PR TITLE
Upgrade to steal 1.0-pre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "main.js",
   "scripts": {
+    "build": "steal-tools",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
@@ -13,7 +14,7 @@
     "jquery": "1.11.1",
     "lodash": "^4.0.1",
     "moment": "^2.11.1",
-    "steal": "^0.13.2"
+    "steal": "^1.0.0-pre.0"
   },
   "system": {
     "npmAlgorithm": "flat",


### PR DESCRIPTION
This updates to the prerelease of Steal 1.0, which uses Babel 6 and no
longer has this bug. `default` must always be used.

To see working in production run:

```
npm run build
```

And change your main.html file to use steal.production.js